### PR TITLE
Update populated places to include "landuse" = "Residential"

### DIFF
--- a/config.json
+++ b/config.json
@@ -301,17 +301,19 @@
                     "caveats": "OpenStreetMap data is crowd sourced and cannot be considered to be exhaustive"
                 },
                 "types": [
-                    "points"
+                    "points",
+                    "polygons"
                 ],
                 "select": [
                     "name",
                     "name:en",
                     "place",
+                    "landuse",
                     "population",
                     "is_in",
                     "source"
                 ],
-                "where": "tags['place'] IN ('isolated_dwelling', 'town', 'village', 'hamlet', 'city')",
+                "where": "tags['place'] IN ('isolated_dwelling', 'town', 'village', 'hamlet', 'city') OR tags['landuse'] IN ('residential')",
                 "formats": [
                     "geojson",
                     "shp",


### PR DESCRIPTION
Description:

Based on partner feedback and insights from [this report](https://observablehq.com/@h2h/improving-and-analyzing-osm-populated-places), this change assigns **landuse = Residential** to populated places for more accurate classification.
 