### PR TITLE
Add 'subnational' flag to HDX exports

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "include_stats": true,
     "include_stats_html": true,
     "hdx_upload": true,
+    "subnational": true,
     "categories": [
         {
             "Buildings": {


### PR DESCRIPTION
<img width="667" height="229" alt="image" src="https://github.com/user-attachments/assets/9c011026-8cd0-4a66-9478-8cbb675c1d40" />

- Request from HDX team.
- Country exports should include the `subnational` flag.