### PR TITLE
Document new Windmill workflows approach, before deploy

### DIFF
--- a/docs/main-windmill-example.py
+++ b/docs/main-windmill-example.py
@@ -1,0 +1,88 @@
+#requirements:
+#oex==0.4.1
+
+"""Windmill entrypoint: export one country's OSM data via oex.
+
+One country per run - the library equivalent of
+`oex-cli osm --config <cfg> --iso3 <ISO3>`. Windmill builds the run form from
+main()'s signature, and the dispatcher flow calls this once per country with
+args pulled from scripts/countries.yaml.
+
+Tag this script `heavy` in Windmill so it only runs on the high-memory pool.
+"""
+
+import os
+from pathlib import Path
+
+from oex.config.loader import apply_overrides, load_config, select_categories
+from oex.exporter import Exporter
+from oex.osm.runner import OsmRunner
+
+# Where the repo lives on the worker (configs/ + _hot-schema.yaml). Baked into
+# the heavy worker image; point OEX_REPO_DIR elsewhere to override.
+REPO_DIR = Path(os.environ.get("OEX_REPO_DIR", "/opt/osm-country-exports"))
+
+
+def _resolve_config(iso3: str, config_path: str) -> Path:
+    """Explicit path wins, else the per-country override, else base.yaml.
+
+    Same rule as scripts/sweep.sh.
+    """
+    if config_path:
+        return Path(config_path)
+    override = REPO_DIR / "configs" / "countries" / f"{iso3}.yaml"
+    return override if override.exists() else REPO_DIR / "configs" / "base.yaml"
+
+
+def main(
+    iso3: str,
+    priority: int = 50,        # queue priority (1-100); set on the job by the dispatcher
+    cadence: str = "monthly",  # which schedule fired this run; metadata only
+    hdx_push: bool = True,
+    config_path: str = "",     # blank = auto-resolve (see _resolve_config)
+    theme: str = "",           # optional single-theme run, e.g. "buildings"
+    engine: str = "",          # optional OSM engine override: geofabrik | planet
+    dataset_name: str = "",    # optional {country} label for HDX titles (e.g. "DRC")
+):
+    iso3 = iso3.upper()
+
+    # oex resolves relative paths (categories_file, cache dirs) from the CWD,
+    # exactly as the CLI does when run from the repo root.
+    os.chdir(REPO_DIR)
+
+    cfg_path = _resolve_config(iso3, config_path)
+    if not cfg_path.exists():
+        raise FileNotFoundError(f"config not found: {cfg_path}")
+
+    overrides: dict[str, object] = {"iso3": iso3, "hdx.push": hdx_push}
+    if engine:
+        overrides["source.osm.engine"] = engine
+    if dataset_name:
+        overrides["dataset_name"] = dataset_name
+
+    cfg = load_config(cfg_path)
+    cfg = apply_overrides(cfg, overrides)
+    cfg = select_categories(cfg, theme or None)
+
+    result = Exporter(cfg, OsmRunner()).run()
+
+    summary = {
+        "iso3": result.iso3,
+        "source": result.source_name,
+        "config": str(cfg_path),
+        "priority": priority,
+        "cadence": cadence,
+        "succeeded": result.succeeded,
+        "empty": result.empty,
+        "skipped": result.skipped,
+        "failed": result.failed,
+        "duration_s": round(result.total_duration_s, 1),
+    }
+
+    # Fail the job (and the loop iteration) if any category failed, so it shows
+    # red and is easy to re-run. "Continue on error" on the flow step keeps the
+    # rest of the batch running.
+    if result.failed:
+        raise RuntimeError(f"{iso3}: {result.failed} categories failed - {summary}")
+
+    return summary

--- a/docs/windmill.md
+++ b/docs/windmill.md
@@ -1,0 +1,111 @@
+# Country exports on Windmill
+
+Monthly (and weekly/daily) OSM exports for ~40 countries, run as high-memory
+batch jobs on [Windmill](https://www.windmill.dev/).
+
+## The idea
+
+```
+3 schedules ──▶ dispatcher flow          (light worker)
+ daily            reads scripts/countries.yaml
+ weekly           runs main.py once per country, ~2 at a time
+ monthly          ├──▶ main.py  iso3=AFG   [heavy]
+                  ├──▶ main.py  iso3=SDN   [heavy]
+                  └──▶ main.py  iso3=...   [heavy]
+```
+
+Every country runs the **same script** (`main.py`) with **different arguments**.
+The arguments come from `scripts/countries.yaml`, which stays the source of
+truth - adding a country is still a one-line edit there.
+
+- **`main.py`** - the export itself. One country per run. Tagged `heavy` so it
+  only lands on the high-memory worker pool.
+- **Dispatcher flow** - a thin coordinator on a normal worker. Reads
+  `countries.yaml` and launches one `heavy` job per country.
+- **Schedules** - three of them (daily/weekly/monthly), each just runs the
+  dispatcher with a different `cadence` argument. Replaces the three GitHub
+  Actions.
+
+The worker pool, the `heavy` tag, KEDA autoscaling and Karpenter spot instances
+are all set up in [hotosm/k8s-infra](https://github.com/hotosm/k8s-infra). This
+repo only holds the script, the flow and the schedules.
+
+## How scaling works
+
+1. The dispatcher queues one `heavy` job per country.
+2. The `heavy` worker pool listens on that queue; KEDA sees the jobs and scales
+   it up from zero.
+3. No room in the cluster? Karpenter spins up a spot instance.
+4. Workers chew through ~2 at a time, then the pool scales back to zero once the
+   queue is empty.
+
+Only `main.py` is `heavy`. The dispatcher is light, so coordinating the run
+never ties up a high-memory slot.
+
+## The script
+
+`main.py` is one country, one run - the same as `just one <ISO3>` today.
+Windmill builds the run form from the function arguments automatically.
+
+```python
+def main(
+    iso3: str,
+    priority: int = 50,        # queue priority (1-100), set by the dispatcher
+    cadence: str = "monthly",  # which schedule fired this
+    hdx_push: bool = True,
+    config_path: str = "",     # blank = auto: countries/<ISO3>.yaml, else base.yaml
+):
+    ...
+```
+
+Config lookup is the same rule as `sweep.sh`: use `configs/countries/<ISO3>.yaml`
+if it exists, otherwise `configs/base.yaml`.
+
+## How the 3 params map
+
+- **country code** - the `iso3` argument, one per loop item.
+- **frequency** - the `cadence:` value in `countries.yaml` decides which of the
+  three schedules picks the country up.
+- **priority** - the group (`priority`/`normal`/`big`). The dispatcher runs the
+  priority group first and gives those jobs a higher Windmill priority number,
+  so they jump the queue when `heavy` slots are tight.
+
+## The dispatcher flow
+
+Two steps:
+
+1. **List** (light) - reads `countries.yaml` for the fired cadence and returns
+   `[{iso3, config, priority}, ...]`, ordered priority → normal → big. Basically
+   `list_countries.py` returning structured rows.
+2. **For-loop** over that list, running `main.py` per country:
+   - **Parallel, parallelism = 2** - the "a couple at a time" knob. Bump it once
+     the pool scales comfortably.
+   - **Continue on error** - one failed country doesn't kill the run; it just
+     shows up as a failed iteration.
+   - The loop step is tagged `heavy`; the flow itself is not.
+
+## Deploying (git sync)
+
+The script, flow and schedules live in this repo and sync to Windmill - that's
+how "Windmill points to the remote script".
+
+- Use `wmill` git sync with `includeSchedules: true` in `wmill.yaml` (schedules
+  are off by default).
+- Run it from a GitHub Action on push to `main`, so merging a PR deploys
+  everything with no clicking in the UI.
+
+## Running it
+
+- **Full run** - happens automatically on schedule. To kick one off now, open
+  the dispatcher flow and run it with the cadence you want.
+- **One country** - run `main.py` from its form with a single `iso3`. No flow
+  needed. Same as `just one <ISO3>`.
+- **Restart failed countries** - two options, both safe:
+  1. Open the failed country's job and hit **Re-run**. Isolated - won't touch
+     other countries. (Best for one-offs.)
+  2. On the flow run, pick the failed step and **Restart from here**. Windmill
+     skips the countries that already succeeded.
+
+  Re-running is safe either way: completed countries are skipped,
+  `output.resume: true` resumes a partial export, and HDX/S3 writes overwrite in
+  place.


### PR DESCRIPTION
Fixes #10

- I just set up a new Windmill worker pool based on the `heavy` tag - see the linked issue comment.
- In this PR I added a concise AI-gen document (Opus 4.8) based on the infra I deployed in k8s-infra, and my notes on what to do next - I proof-read and validated the content.
- Also generated an example main.py to show the dispatcher pattern in practice.

TODO:
- [x] The script needs the `oex` dependency and the `configs/` directory from this repo. So we either need to install / pull them on each run (not ideal!) or bake into a container image (preferred). The problem with baking into an image, is that we would need to add them to the Windmill `heavy` worker image... which also isn't ideal (will come back to this, unless someone has ideas? The approach using Kubernetes CronJob does solve this one, by using a specific image...).
  - We will simply do the `oex` install as part of the script for now, then evaluate extending images from https://github.com/windmill-labs/windmill/blob/main/Dockerfile (need to add extra deps to the python env, tag, push to ghcr.io/hotosm, and set as `image` and `tag` params for groups/labels [here](https://github.com/hotosm/k8s-infra/blob/813fc6e3f812eebb763a4aa25fa5e424f6e0917e/apps/windmill/helm/values.yaml#L13)
- [x] Are 2 exports at a time enough? Any idea how long each one will take?
  - Two are enough for now, evaluate if takes too much time or stuck jobs.
  - Time depends on location. 1hr normal, max 4-5 hours for big countries (we can skip them for now)
  - `osm-export-small`: 8GB + 2 vCPU
  - `osm-export-medium`: 16GB + 4 vCPU
    - We should set all 'big' country exports to use medium first. If they fail, bump to big label.
  - `osm-export-big`: 32GB + 4 vCPU
- [x] Are the resources provisioned definitely enough? 4 core + 12GB RAM.
- [x] ~Implement the `heavy` worker group / tag in Windmill.~
- [ ] Secrets: we need to set these as Windmill variables, instead of .env.
  - raw-data-export IAM role, security creds for the S3.
- [ ] Implement the script in Windmill to do the processing.
- [ ] Cleanup the old github actions & systemd stuff in the repo after we implement.